### PR TITLE
Created a numerical hierarchy for status

### DIFF
--- a/src/components/Keyboard/store.ts
+++ b/src/components/Keyboard/store.ts
@@ -1,5 +1,17 @@
-import type { Guess, IKeyboardStore } from '$lib/types';
+import type { CharStatus, Guess, IKeyboardStore } from '$lib/types';
 import { writable } from 'svelte/store';
+/**
+ * By converting the statuses into numbers,
+ * we can create a hierarchy that can be logically tested to determine the most correct status
+ *
+ * The idea being that the highest number is the most correct
+ */
+function translateHierarchy(status?: CharStatus) {
+	if (status === 'absent') return 1;
+	if (status === 'present') return 2;
+	if (status === 'correct') return 3;
+	return 0;
+}
 
 function createKeyboardStore() {
 	const init = { letterStatus: new Map(), disabled: false };
@@ -12,7 +24,11 @@ function createKeyboardStore() {
 		setLetterStatus: (guess: Guess) => {
 			update(({ letterStatus, ...rest }) => {
 				guess.letters.forEach((char, i) => {
-					if (letterStatus.get(char) !== 'correct') letterStatus.set(char, guess.statuses[i]);
+					const currentStatus = translateHierarchy(letterStatus.get(char));
+					const incomingStatus = translateHierarchy(guess.statuses[i]);
+					if (incomingStatus > currentStatus) {
+						letterStatus.set(char, guess.statuses[i]);
+					}
 				});
 				return { letterStatus, ...rest };
 			});


### PR DESCRIPTION
Fixes #1 - The comment explains the fix but basically, the idea is to create a status hierarchy based on correctness, this way only the most correct status (with no status represented as zero) will cause an update to the keyboard, even if a less correct status precedes it